### PR TITLE
Fix classmetrics plugin errors

### DIFF
--- a/classes/condition.php
+++ b/classes/condition.php
@@ -4,10 +4,10 @@ namespace availability_classmetrics;
 
 defined("MOODLE_INTERNAL") || die();
 
-use core_availability\condition;
+use core_availability\condition as core_condition;
 use core_availability\info;
 
-class condition extends \core_availability\condition {
+class condition extends core_condition {
 
     protected $type;
     protected $percentage;

--- a/classes/frontend.php
+++ b/classes/frontend.php
@@ -4,9 +4,9 @@ namespace availability_classmetrics;
 
 defined("MOODLE_INTERNAL") || die();
 
-use core_availability\frontend;
+use core_availability\frontend as core_frontend;
 
-class frontend extends \core_availability\frontend {
+class frontend extends core_frontend {
 
     protected function get_javascript_strings() {
         return [
@@ -31,13 +31,14 @@ class frontend extends \core_availability\frontend {
         // Get course activities with completion enabled
         $activities = [];
         $coursemodules = $DB->get_records("course_modules", ["course" => $course->id]);
+        $modinfo = get_fast_modinfo($course);
         foreach ($coursemodules as $cm) {
-            $modinfo = get_module_info($cm->id);
-            if ($modinfo && $modinfo->completion != COMPLETION_DISABLED) {
+            $cminfo = $modinfo->get_cm($cm->id);
+            if ($cminfo && $cminfo->completion != COMPLETION_DISABLED) {
                 $activities[] = [
                     'id' => $cm->id,
-                    'name' => $modinfo->name,
-                    'modname' => $modinfo->modname
+                    'name' => $cminfo->name,
+                    'modname' => $cminfo->modname
                 ];
             }
         }
@@ -52,9 +53,10 @@ class frontend extends \core_availability\frontend {
             ];
         }
         
+        // Return data as a numeric array to match JavaScript expectations.
         return [
-            'activities' => $activities,
-            'groups' => $groups
+            $activities,
+            $groups
         ];
     }
 

--- a/yui/src/form/js/form.js
+++ b/yui/src/form/js/form.js
@@ -229,13 +229,19 @@ M.availability_classmetrics.form = Y.Object(M.core_availability.plugin, {
         
         // Add event handlers
         var self = this;
+        var updateForm = function() {
+            if (M.core_availability && M.core_availability.form) {
+                M.core_availability.form.update();
+            }
+        };
+
         node.one('select[name=conditiontype]').on('change', function() {
             self.updateVisibility();
-            M.core_availability.form.update();
+            updateForm();
         });
-        
+
         node.all('input, select').on('change', function() {
-            M.core_availability.form.update();
+            updateForm();
         });
         
         // Set initial visibility
@@ -261,7 +267,7 @@ M.availability_classmetrics.form = Y.Object(M.core_availability.plugin, {
                 errors.push('availability_classmetrics:error_percentage');
             }
             if (!value.activities || value.activities === '') {
-                errors.push('Selecione pelo menos uma atividade');
+                errors.push('availability_classmetrics:error_activities');
             }
         } else if (value.conditiontype === 'students') {
             if (value.minimum === undefined || value.minimum < 1) {


### PR DESCRIPTION
## Summary
- alias core availability classes to avoid name collisions
- use Moodle modinfo API to retrieve course module data
- reference language string for missing activity selection error
- pass init parameters as numeric array and guard availability form update

## Testing
- `phpunit` *(fails: command not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68af8865416483289cac37be5ba08804