### PR TITLE
fix: register availability plugin

### DIFF
--- a/yui/build/moodle-availability_classmetrics-form/moodle-availability_classmetrics-form.js
+++ b/yui/build/moodle-availability_classmetrics-form/moodle-availability_classmetrics-form.js
@@ -142,5 +142,6 @@ YUI.add('moodle-availability_classmetrics-form', function(Y, NAME) {
     }
 };
 
+M.core_availability.form.addPlugin(M.availability_classmetrics.form);
 
 }, '1.0.0', { requires: ['base', 'node', 'event', 'moodle-core_availability-form'] });


### PR DESCRIPTION
## Summary
- register availability_classmetrics form with core availability to ensure restrictions persist

## Testing
- `node --check yui/build/moodle-availability_classmetrics-form/moodle-availability_classmetrics-form.js`
- `php -l classes/condition.php`


------
https://chatgpt.com/codex/tasks/task_b_68b0e4a5f0848328a54f87634a01254b